### PR TITLE
Increase delay between email attempts

### DIFF
--- a/omero_signup/signup_settings.py
+++ b/omero_signup/signup_settings.py
@@ -38,12 +38,9 @@ SIGNUP_SETTINGS_MAPPING = {
         ), str_not_empty, None],
     'omero.web.signup.helpmessage':
         ['SIGNUP_HELP_MESSAGE', '', str, None],
-    'omero.web.signup.email.maxtries':
-        ['SIGNUP_EMAIL_MAXTRIES', 3, int,
-         "Maximum number of tries when attempting to send an email."],
     'omero.web.signup.email.delay':
-        ['SIGNUP_EMAIL_DELAY', 4, int,
-         "Delay in between attempts to send an email in seconds."]
+        ['SIGNUP_EMAIL_DELAY', 5000, int,
+         "Delay in between attempts to send an email in milliseconds."]
 }
 
 

--- a/omero_signup/signup_settings.py
+++ b/omero_signup/signup_settings.py
@@ -38,6 +38,12 @@ SIGNUP_SETTINGS_MAPPING = {
         ), str_not_empty, None],
     'omero.web.signup.helpmessage':
         ['SIGNUP_HELP_MESSAGE', '', str, None],
+    'omero.web.signup.email.maxtries':
+        ['SIGNUP_EMAIL_MAXTRIES', 3, int,
+         "Maximum number of tries when attempting to send an email."],
+    'omero.web.signup.email.delay':
+        ['SIGNUP_EMAIL_DELAY', 4, int,
+         "Delay in between attempts to send an email in seconds."]
 }
 
 

--- a/omero_signup/views.py
+++ b/omero_signup/views.py
@@ -4,7 +4,6 @@
 import logging
 import random
 import string
-import time
 from datetime import datetime
 from uuid import uuid4
 
@@ -230,26 +229,12 @@ class WebSignupView(View):
             groupIds=[],
             everyone=False,
             inactive=True)
-
-        maxtries = signup_settings.SIGNUP_EMAIL_MAXTRIES
-        delay = signup_settings.SIGNUP_EMAIL_DELAY
-        retries = 0
-
-        while True:
-            try:
-                cb = client.submit(req, loops=10, ms=500,
-                                   failonerror=True, failontimeout=True)
-                rsp = cb.getResponse()
-                if rsp.invalidemails:
-                    raise Exception('Invalid email: %s' % rsp.invalidemails)
-                break
-            except omero.LockTimeout as e:
-                if retries < maxtries - 1:
-                    logger.warn(f"{e.message}, Retrying in {delay} seconds")
-                    retries += 1
-                    time.sleep(delay)
-                    continue
-                else:
-                    raise
-            finally:
-                cb.close(True)
+        cb = client.submit(
+            req, loops=10, ms=signup_settings.SIGNUP_EMAIL_DELAY,
+            failonerror=True, failontimeout=True)
+        try:
+            rsp = cb.getResponse()
+            if rsp.invalidemails:
+                raise Exception('Invalid email: %s' % rsp.invalidemails)
+        finally:
+            cb.close(True)


### PR DESCRIPTION
Fixes #8 

This commits attempts to mitigate LockTimeout exceptions thrown during an email request. 

The default behavior is to try the SendEmailCmd 10 times with a 500ms delay. This PR makes the delay between attempts configurable and increases the default value to 5000ms.